### PR TITLE
fix: pytest for db to correct db filename

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def friday():
 @pytest.fixture
 def engine():
     """Re-initialize the database."""
-    return DB.configure("sqlite")
+    return DB.configure("test")
 
 
 @pytest.fixture


### PR DESCRIPTION
This hotfix seems useful if anyone else also wants to contribute, otherwise I'll batch up sensible changes in the future.